### PR TITLE
ACM-23014 Implemented managed cluster discovery from cluster sets and basic get ClusterPermission functionality

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,8 +3,10 @@ approvers:
   - kurwang
   - Ginxo
   - mshort55
+  - fxiang1
 reviewers:
   - oksanabaza
   - kurwang
   - Ginxo
   - mshort55
+  - fxiang1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,7 @@ rules:
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
+  - managedclusters
   - managedclustersets
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,6 +16,7 @@ rules:
 - apiGroups:
   - rbac.open-cluster-management.io
   resources:
+  - clusterpermissions
   - multiclusterroleassignments
   verbs:
   - create

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
+	open-cluster-management.io/api v1.0.0
+	open-cluster-management.io/cluster-permission v0.15.0
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 
@@ -20,6 +22,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
@@ -89,7 +92,6 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
-	open-cluster-management.io/api v1.0.0
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
-github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ2tG6yudJd8LBksgI=
+github.com/evanphx/json-patch v5.7.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -243,6 +243,8 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6J
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 open-cluster-management.io/api v1.0.0 h1:54QllH9DTudCk6VrGt0q8CDsE3MghqJeTaTN4RHZpE0=
 open-cluster-management.io/api v1.0.0/go.mod h1:/OeqXycNBZQoe3WG6ghuWsMgsKGuMZrK8ZpsU6gWL0Y=
+open-cluster-management.io/cluster-permission v0.15.0 h1:nE5igoyKK/w14dGDjrDYnZxaZTfG0YSiIH2gaIX8Yso=
+open-cluster-management.io/cluster-permission v0.15.0/go.mod h1:Ejytz7ZDoxDWqiGSDDYYIYKGZQHUgFZuCgFqvTnZSzE=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=

--- a/internal/controller/multiclusterroleassignment_controller_test.go
+++ b/internal/controller/multiclusterroleassignment_controller_test.go
@@ -241,10 +241,10 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 					Expect(roleAssignmentStatus.Status).To(Equal(StatusTypeError))
 					Expect(roleAssignmentStatus.Message).To(ContainSubstring(MessageMissingManagedClusterSets))
 					switch roleAssignmentStatus.Name {
-					case "test-assignment-1":
+					case roleAssignment1Name:
 						Expect(roleAssignmentStatus.Message).To(ContainSubstring("missing-set1"))
 						Expect(roleAssignmentStatus.Message).To(ContainSubstring("missing-set2"))
-					case "test-assignment-2":
+					case roleAssignment2Name:
 						Expect(roleAssignmentStatus.Message).To(ContainSubstring("missing-set1"))
 						Expect(roleAssignmentStatus.Message).NotTo(ContainSubstring("missing-set2"))
 					}
@@ -582,7 +582,7 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 		})
 
 		AfterEach(func() {
-			k8sClient.Delete(ctx, cp)
+			_ = k8sClient.Delete(ctx, cp)
 		})
 
 		Describe("getClusterPermission", func() {

--- a/internal/controller/multiclusterroleassignment_controller_test.go
+++ b/internal/controller/multiclusterroleassignment_controller_test.go
@@ -29,6 +29,7 @@ import (
 	rbacv1alpha1 "github.com/stolostron/multicluster-role-assignment/api/v1alpha1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 )
 
@@ -205,7 +206,7 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 
 				Expect(mra.Status.RoleAssignments).To(HaveLen(2))
 				for _, roleAssignmentStatus := range mra.Status.RoleAssignments {
-					Expect(roleAssignmentStatus.Status).To(Equal(StateTypePending))
+					Expect(roleAssignmentStatus.Status).To(Equal(StatusTypePending))
 					Expect(roleAssignmentStatus.Message).To(Equal(MessageManagedClusterSetValidationPassed))
 				}
 			})
@@ -236,8 +237,16 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 				Expect(mra.Status.RoleAssignments).To(HaveLen(2))
 
 				for _, roleAssignmentStatus := range mra.Status.RoleAssignments {
-					Expect(roleAssignmentStatus.Status).To(Equal(StateTypeError))
-					Expect(roleAssignmentStatus.Message).To(ContainSubstring("Missing ManagedClusterSets"))
+					Expect(roleAssignmentStatus.Status).To(Equal(StatusTypeError))
+					Expect(roleAssignmentStatus.Message).To(ContainSubstring(MessageMissingManagedClusterSets))
+					switch roleAssignmentStatus.Name {
+					case "test-assignment-1":
+						Expect(roleAssignmentStatus.Message).To(ContainSubstring("missing-set1"))
+						Expect(roleAssignmentStatus.Message).To(ContainSubstring("missing-set2"))
+					case "test-assignment-2":
+						Expect(roleAssignmentStatus.Message).To(ContainSubstring("missing-set1"))
+						Expect(roleAssignmentStatus.Message).NotTo(ContainSubstring("missing-set2"))
+					}
 				}
 			})
 		})
@@ -290,23 +299,28 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 
 			Describe("setRoleAssignmentStatus", func() {
 				It("Should add new role assignment status when not present", func() {
-					reconciler.setRoleAssignmentStatus(mra, "assignment1", StateTypeActive, "Successfully applied")
+					reconciler.setRoleAssignmentStatus(mra, "assignment1", StatusTypeActive, "TestReason",
+						"Successfully applied")
 
 					Expect(mra.Status.RoleAssignments).To(HaveLen(1))
 					status := mra.Status.RoleAssignments[0]
 					Expect(status.Name).To(Equal("assignment1"))
-					Expect(status.Status).To(Equal(StateTypeActive))
+					Expect(status.Status).To(Equal(StatusTypeActive))
+					Expect(status.Reason).To(Equal("TestReason"))
 					Expect(status.Message).To(Equal("Successfully applied"))
 				})
 
 				It("Should update existing role assignment status", func() {
-					reconciler.setRoleAssignmentStatus(mra, "assignment1", StateTypePending, "Initializing")
-					reconciler.setRoleAssignmentStatus(mra, "assignment1", StateTypeActive, "Successfully applied")
+					reconciler.setRoleAssignmentStatus(mra, "assignment1", StatusTypePending, "TestReasonPending",
+						"Initializing")
+					reconciler.setRoleAssignmentStatus(mra, "assignment1", StatusTypeActive, "TestReasonActive",
+						"Successfully applied")
 
 					Expect(mra.Status.RoleAssignments).To(HaveLen(1))
 					status := mra.Status.RoleAssignments[0]
 					Expect(status.Name).To(Equal("assignment1"))
-					Expect(status.Status).To(Equal(StateTypeActive))
+					Expect(status.Status).To(Equal(StatusTypeActive))
+					Expect(status.Reason).To(Equal("TestReasonActive"))
 					Expect(status.Message).To(Equal("Successfully applied"))
 				})
 			})
@@ -318,7 +332,7 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 					Expect(mra.Status.RoleAssignments).To(HaveLen(2))
 
 					for _, roleAssignmentStatus := range mra.Status.RoleAssignments {
-						Expect(roleAssignmentStatus.Status).To(Equal(StateTypePending))
+						Expect(roleAssignmentStatus.Status).To(Equal(StatusTypePending))
 						Expect(roleAssignmentStatus.Message).To(Equal(MessageInitializingRoleAssignment))
 					}
 				})
@@ -327,7 +341,7 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 					mra.Status.RoleAssignments = []rbacv1alpha1.RoleAssignmentStatus{
 						{
 							Name:    roleAssignment1Name,
-							Status:  StateTypeActive,
+							Status:  StatusTypeActive,
 							Message: "Already applied",
 						},
 					}
@@ -341,10 +355,10 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 
 						switch status.Name {
 						case roleAssignment1Name:
-							Expect(status.Status).To(Equal(StateTypeActive))
+							Expect(status.Status).To(Equal(StatusTypeActive))
 							Expect(status.Message).To(Equal("Already applied"))
 						case roleAssignment2Name:
-							Expect(status.Status).To(Equal(StateTypePending))
+							Expect(status.Status).To(Equal(StatusTypePending))
 							Expect(status.Message).To(Equal(MessageInitializingRoleAssignment))
 						}
 					}
@@ -367,11 +381,11 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 					mra.Status.RoleAssignments = []rbacv1alpha1.RoleAssignmentStatus{
 						{
 							Name:   roleAssignment1Name,
-							Status: StateTypeActive,
+							Status: StatusTypeActive,
 						},
 						{
 							Name:   roleAssignment2Name,
-							Status: StateTypeActive,
+							Status: StatusTypeActive,
 						},
 					}
 				})
@@ -386,7 +400,7 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 				})
 
 				It("Should return False when any role assignment failed", func() {
-					mra.Status.RoleAssignments[1].Status = StateTypeError
+					mra.Status.RoleAssignments[1].Status = StatusTypeError
 
 					status, reason, message := reconciler.calculateReadyCondition(mra)
 					Expect(status).To(Equal(metav1.ConditionFalse))
@@ -395,11 +409,11 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 				})
 
 				It("Should return Unknown when some role assignments are pending", func() {
-					mra.Status.RoleAssignments[1].Status = StateTypePending
+					mra.Status.RoleAssignments[1].Status = StatusTypePending
 					mra.Status.Conditions = mra.Status.Conditions[:1] // Keep only Validated condition
 
 					status, reason, message := reconciler.calculateReadyCondition(mra)
-					Expect(status).To(Equal(metav1.ConditionUnknown))
+					Expect(status).To(Equal(metav1.ConditionFalse))
 					Expect(reason).To(Equal(ReasonInProgress))
 					Expect(message).To(Equal(fmt.Sprintf("1 out of 2 %s", MessageRoleAssignmentsPending)))
 				})
@@ -419,6 +433,132 @@ var _ = Describe("MulticlusterRoleAssignment Controller", func() {
 					Expect(reason).To(Equal(ReasonUnknown))
 					Expect(message).To(Equal(MessageStatusCannotBeDetermined))
 				})
+			})
+		})
+	})
+	Context("Cluster Discovery Tests", func() {
+		const cluster1Name = "test-cluster-1"
+		const cluster2Name = "test-cluster-2"
+		const cluster3Name = "test-cluster-3"
+
+		BeforeEach(func() {
+			By("Creating ManagedClusters for cluster discovery tests")
+
+			cluster1 := &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster1Name,
+					Labels: map[string]string{
+						"cluster.open-cluster-management.io/clusterset": clusterSet1Name,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster1)).To(Succeed())
+
+			cluster2 := &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster2Name,
+					Labels: map[string]string{
+						"cluster.open-cluster-management.io/clusterset": clusterSet1Name,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster2)).To(Succeed())
+
+			cluster3 := &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cluster3Name,
+					Labels: map[string]string{
+						"cluster.open-cluster-management.io/clusterset": clusterSet2Name,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster3)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("Cleaning up ManagedClusters")
+			cluster1 := &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: cluster1Name}}
+			Expect(k8sClient.Delete(ctx, cluster1)).To(Succeed())
+
+			cluster2 := &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: cluster2Name}}
+			Expect(k8sClient.Delete(ctx, cluster2)).To(Succeed())
+
+			cluster3 := &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: cluster3Name}}
+			Expect(k8sClient.Delete(ctx, cluster3)).To(Succeed())
+		})
+
+		Describe("discoverManagedClusters", func() {
+			It("Should discover clusters from multiple cluster sets", func() {
+				clusters, err := reconciler.discoverManagedClusters(ctx, mra)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(clusters).To(HaveLen(3))
+				Expect(clusters).To(ContainElements(cluster1Name, cluster2Name, cluster3Name))
+			})
+
+			It("Should update role assignment statuses during discovery", func() {
+				_, err := reconciler.discoverManagedClusters(ctx, mra)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mra.Status.RoleAssignments).To(HaveLen(2))
+
+				for _, roleAssignmentStatus := range mra.Status.RoleAssignments {
+					Expect(roleAssignmentStatus.Status).To(Equal(StatusTypePending))
+					switch roleAssignmentStatus.Name {
+					case "test-assignment-1":
+						Expect(roleAssignmentStatus.Message).To(Equal(MessageManagedClustersDiscovered +
+							": [test-cluster-1 test-cluster-2]"))
+					case "test-assignment-2":
+						Expect(roleAssignmentStatus.Message).To(Equal(MessageManagedClustersDiscovered +
+							": [test-cluster-3]"))
+					}
+				}
+			})
+
+			It("Should handle missing cluster sets gracefully", func() {
+				mra.Spec.RoleAssignments[0].ClusterSets = []string{"non-existent-cluster-set", clusterSet1Name}
+
+				clusters, err := reconciler.discoverManagedClusters(ctx, mra)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(clusters).To(ContainElements(cluster1Name, cluster2Name))
+			})
+		})
+
+		Describe("Full reconciliation with cluster discovery", func() {
+			It("Should successfully reconcile and discover clusters", func() {
+				By("Reconciling the MulticlusterRoleAssignment with cluster discovery")
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: mraNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying the MulticlusterRoleAssignment status after reconciliation")
+				err = k8sClient.Get(ctx, mraNamespacedName, mra)
+				Expect(err).NotTo(HaveOccurred())
+
+				fmt.Println(mra)
+
+				found := false
+				for _, condition := range mra.Status.Conditions {
+					if condition.Type == ConditionTypeValidated {
+						Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+						Expect(condition.Reason).To(Equal(ReasonSpecIsValid))
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue(), "Validated condition should be True")
+
+				Expect(mra.Status.RoleAssignments).To(HaveLen(2))
+				for _, roleAssignmentStatus := range mra.Status.RoleAssignments {
+					Expect(roleAssignmentStatus.Status).To(Equal(StatusTypePending))
+					switch roleAssignmentStatus.Name {
+					case "test-assignment-1":
+						Expect(roleAssignmentStatus.Message).To(Equal(MessageManagedClustersDiscovered +
+							": [test-cluster-1 test-cluster-2]"))
+					case "test-assignment-2":
+						Expect(roleAssignmentStatus.Message).To(Equal(MessageManagedClustersDiscovered +
+							": [test-cluster-3]"))
+					}
+				}
 			})
 		})
 	})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	rbacv1alpha1 "github.com/stolostron/multicluster-role-assignment/api/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	// +kubebuilder:scaffold:imports
@@ -61,6 +62,9 @@ var _ = BeforeSuite(func() {
 
 	var err error
 	err = rbacv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = clusterv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = clusterv1beta2.AddToScheme(scheme.Scheme)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -34,6 +34,7 @@ import (
 	rbacv1alpha1 "github.com/stolostron/multicluster-role-assignment/api/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
+	clusterpermissionv1alpha1 "open-cluster-management.io/cluster-permission/api/v1alpha1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	// +kubebuilder:scaffold:imports
 )
@@ -68,6 +69,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = clusterv1beta2.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = clusterpermissionv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/test/crd/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
+++ b/test/crd/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
@@ -1,0 +1,284 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managedclusters.cluster.open-cluster-management.io
+spec:
+  group: cluster.open-cluster-management.io
+  names:
+    kind: ManagedCluster
+    listKind: ManagedClusterList
+    plural: managedclusters
+    shortNames:
+    - mcl
+    - mcls
+    singular: managedcluster
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hubAcceptsClient
+      name: Hub Accepted
+      type: boolean
+    - jsonPath: .spec.managedClusterClientConfigs[*].url
+      name: Managed Cluster URLs
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ManagedClusterJoined")].status
+      name: Joined
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ManagedClusterConditionAvailable")].status
+      name: Available
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ManagedCluster represents the desired state and current status
+          of a managed cluster. ManagedCluster is a cluster-scoped resource. The name
+          is the cluster UID.
+
+          The cluster join process is a double opt-in process. See the following join process steps:
+
+          1. The agent on the managed cluster creates a CSR on the hub with the cluster UID and agent name.
+          2. The agent on the managed cluster creates a ManagedCluster on the hub.
+          3. The cluster admin on the hub cluster approves the CSR for the UID and agent name of the ManagedCluster.
+          4. The cluster admin sets the spec.acceptClient of the ManagedCluster to true.
+          5. The cluster admin on the managed cluster creates a credential of the kubeconfig for the hub cluster.
+
+          After the hub cluster creates the cluster namespace, the klusterlet agent on the ManagedCluster pushes
+          the credential to the hub cluster to use against the kube-apiserver of the ManagedCluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec represents a desired configuration for the agent on
+              the managed cluster.
+            properties:
+              hubAcceptsClient:
+                description: |-
+                  hubAcceptsClient represents that hub accepts the joining of Klusterlet agent on
+                  the managed cluster with the hub. The default value is false, and can only be set
+                  true when the user on hub has an RBAC rule to UPDATE on the virtual subresource
+                  of managedclusters/accept.
+                  When the value is set true, a namespace whose name is the same as the name of ManagedCluster
+                  is created on the hub. This namespace represents the managed cluster, also role/rolebinding is created on
+                  the namespace to grant the permision of access from the agent on the managed cluster.
+                  When the value is set to false, the namespace representing the managed cluster is
+                  deleted.
+                type: boolean
+              leaseDurationSeconds:
+                default: 60
+                description: |-
+                  LeaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster.
+                  If its value is zero, the Klusterlet agent will update its lease every 60 seconds by default
+                format: int32
+                type: integer
+              managedClusterClientConfigs:
+                description: |-
+                  ManagedClusterClientConfigs represents a list of the apiserver address of the managed cluster.
+                  If it is empty, the managed cluster has no accessible address for the hub to connect with it.
+                items:
+                  description: ClientConfig represents the apiserver address of the
+                    managed cluster.
+                  properties:
+                    caBundle:
+                      description: |-
+                        CABundle is the ca bundle to connect to apiserver of the managed cluster.
+                        System certs are used if it is not set.
+                      format: byte
+                      type: string
+                    url:
+                      description: URL is the URL of apiserver endpoint of the managed
+                        cluster.
+                      type: string
+                  required:
+                  - url
+                  type: object
+                type: array
+              taints:
+                description: |-
+                  Taints is a property of managed cluster that allow the cluster to be repelled when scheduling.
+                  Taints, including 'ManagedClusterUnavailable' and 'ManagedClusterUnreachable', can not be added/removed by agent
+                  running on the managed cluster; while it's fine to add/remove other taints from either hub cluser or managed cluster.
+                items:
+                  description: |-
+                    The managed cluster this Taint is attached to has the "effect" on
+                    any placement that does not tolerate the Taint.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the effect of the taint on placements that do not tolerate the taint.
+                        Valid effects are NoSelect, PreferNoSelect and NoSelectIfNew.
+                      enum:
+                      - NoSelect
+                      - PreferNoSelect
+                      - NoSelectIfNew
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key applied to a cluster. e.g. bar or foo.example.com/bar.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    timeAdded:
+                      description: TimeAdded represents the time at which the taint
+                        was added.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    value:
+                      description: Value is the taint value corresponding to the taint
+                        key.
+                      maxLength: 1024
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  type: object
+                type: array
+            type: object
+          status:
+            description: Status represents the current status of joined managed cluster
+            properties:
+              allocatable:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Allocatable represents the total allocatable resources
+                  on the managed cluster.
+                type: object
+              capacity:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: |-
+                  Capacity represents the total resource capacity from all nodeStatuses
+                  on the managed cluster.
+                type: object
+              clusterClaims:
+                description: |-
+                  ClusterClaims represents cluster information that a managed cluster claims,
+                  for example a unique cluster identifier (id.k8s.io) and kubernetes version
+                  (kubeversion.open-cluster-management.io). They are written from the managed
+                  cluster. The set of claims is not uniform across a fleet, some claims can be
+                  vendor or version specific and may not be included from all managed clusters.
+                items:
+                  description: ManagedClusterClaim represents a ClusterClaim collected
+                    from a managed cluster.
+                  properties:
+                    name:
+                      description: |-
+                        Name is the name of a ClusterClaim resource on managed cluster. It's a well known
+                        or customized name to identify the claim.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value is a claim-dependent string
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                  type: object
+                type: array
+              conditions:
+                description: Conditions contains the different condition statuses
+                  for this managed cluster.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              version:
+                description: Version represents the kubernetes version of the managed
+                  cluster.
+                properties:
+                  kubernetes:
+                    description: Kubernetes is the kubernetes version of managed cluster.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test/crd/rbac.open-cluster-management.io_clusterpermissions.yaml
+++ b/test/crd/rbac.open-cluster-management.io_clusterpermissions.yaml
@@ -1,0 +1,636 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.0
+  name: clusterpermissions.rbac.open-cluster-management.io
+spec:
+  group: rbac.open-cluster-management.io
+  names:
+    kind: ClusterPermission
+    listKind: ClusterPermissionList
+    plural: clusterpermissions
+    singular: clusterpermission
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPermission is the Schema for the clusterpermissions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterPermissionSpec defines the desired state of ClusterPermission
+            properties:
+              clusterRole:
+                description: ClusterRole represents the ClusterRole that is being
+                  created on the managed cluster
+                properties:
+                  rules:
+                    description: Rules holds all the PolicyRules for this ClusterRole
+                    items:
+                      description: |-
+                        PolicyRule holds information that describes a policy rule, but does not contain information
+                        about who the rule applies to or which namespace the rule applies to.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+                            the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        nonResourceURLs:
+                          description: |-
+                            NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+                            Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+                            Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resourceNames:
+                          description: ResourceNames is an optional white list of
+                            names that the rule applies to.  An empty set means that
+                            everything is allowed.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: Resources is a list of resources this rule
+                            applies to. '*' represents all resources.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        verbs:
+                          description: Verbs is a list of Verbs that apply to ALL
+                            the ResourceKinds contained in this rule. '*' represents
+                            all verbs.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - verbs
+                      type: object
+                    type: array
+                required:
+                - rules
+                type: object
+              clusterRoleBinding:
+                description: ClusterRoleBinding represents the ClusterRoleBinding
+                  that is being created on the managed cluster
+                properties:
+                  name:
+                    description: Name of the ClusterRoleBinding if a name different
+                      than the ClusterPermission name is used
+                    type: string
+                  roleRef:
+                    description: RoleRef contains information that points to the ClusterRole
+                      being used
+                    properties:
+                      apiGroup:
+                        description: APIGroup is the group for the resource being
+                          referenced
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                    required:
+                    - apiGroup
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  subject:
+                    description: |-
+                      Subject contains a reference to the object or user identities a ClusterPermission binding applies to.
+                      Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                      If both subject and subjects exist then only subjects will be used.
+                    properties:
+                      apiGroup:
+                        description: |-
+                          APIGroup holds the API group of the referenced subject.
+                          Defaults to "" for ServiceAccount subjects.
+                          Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                          If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                        type: string
+                      name:
+                        description: Name of the object being referenced.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                          the Authorizer should report an error.
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  subjects:
+                    description: |-
+                      Subjects contains an array of references to objects or user identities a ClusterPermission binding applies to.
+                      Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                      If both subject and subjects exist then only subjects will be used.
+                    items:
+                      description: |-
+                        Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                        or a value for non-objects such as user and group names.
+                      properties:
+                        apiGroup:
+                          description: |-
+                            APIGroup holds the API group of the referenced subject.
+                            Defaults to "" for ServiceAccount subjects.
+                            Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                            If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                          type: string
+                        name:
+                          description: Name of the object being referenced.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                            the Authorizer should report an error.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: Either subject or subjects has to exist in clusterRoleBinding
+                  rule: has(self.subject) || has(self.subjects)
+              clusterRoleBindings:
+                description: ClusterRoleBindings represents multiple ClusterRoleBindings
+                  that are being created on the managed cluster
+                items:
+                  description: ClusterRoleBinding represents the ClusterRoleBinding
+                    that is being created on the managed cluster
+                  properties:
+                    name:
+                      description: Name of the ClusterRoleBinding if a name different
+                        than the ClusterPermission name is used
+                      type: string
+                    roleRef:
+                      description: RoleRef contains information that points to the
+                        ClusterRole being used
+                      properties:
+                        apiGroup:
+                          description: APIGroup is the group for the resource being
+                            referenced
+                          type: string
+                        kind:
+                          description: Kind is the type of resource being referenced
+                          type: string
+                        name:
+                          description: Name is the name of resource being referenced
+                          type: string
+                      required:
+                      - apiGroup
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    subject:
+                      description: |-
+                        Subject contains a reference to the object or user identities a ClusterPermission binding applies to.
+                        Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                        If both subject and subjects exist then only subjects will be used.
+                      properties:
+                        apiGroup:
+                          description: |-
+                            APIGroup holds the API group of the referenced subject.
+                            Defaults to "" for ServiceAccount subjects.
+                            Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                            If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                          type: string
+                        name:
+                          description: Name of the object being referenced.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                            the Authorizer should report an error.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    subjects:
+                      description: |-
+                        Subjects contains an array of references to objects or user identities a ClusterPermission binding applies to.
+                        Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                        If both subject and subjects exist then only subjects will be used.
+                      items:
+                        description: |-
+                          Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                          or a value for non-objects such as user and group names.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup holds the API group of the referenced subject.
+                              Defaults to "" for ServiceAccount subjects.
+                              Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                              If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                            type: string
+                          name:
+                            description: Name of the object being referenced.
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                              the Authorizer should report an error.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                  type: object
+                type: array
+                x-kubernetes-validations:
+                - message: Either subject or subjects has to exist in every clusterRoleBinding
+                  rule: self.all(i, has(i.subject) || has(i.subjects))
+              roleBindings:
+                description: RoleBindings represents RoleBindings that are being created
+                  on the managed cluster
+                items:
+                  description: RoleBinding represents the RoleBinding that is being
+                    created on the managed cluster
+                  properties:
+                    name:
+                      description: Name of the RoleBinding if a name different than
+                        the ClusterPermission name is used
+                      type: string
+                    namespace:
+                      description: Namespace of the Role for that is being created
+                        on the managed cluster
+                      type: string
+                    namespaceSelector:
+                      description: |-
+                        NamespaceSelector define the general labelSelector which namespace to apply the rules to
+                        Note: the namespace must exists on the hub cluster
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    roleRef:
+                      description: RoleRef contains information that points to the
+                        role being used
+                      properties:
+                        apiGroup:
+                          description: APIGroup is the group for the resource being
+                            referenced
+                          type: string
+                        kind:
+                          description: Kind is the type of resource being referenced
+                          type: string
+                        name:
+                          description: Name is the name of resource being referenced
+                          type: string
+                      required:
+                      - kind
+                      type: object
+                    subject:
+                      description: |-
+                        Subject contains a reference to the object or user identities a ClusterPermission binding applies to.
+                        Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                        If both subject and subjects exist then only subjects will be used.
+                      properties:
+                        apiGroup:
+                          description: |-
+                            APIGroup holds the API group of the referenced subject.
+                            Defaults to "" for ServiceAccount subjects.
+                            Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                            If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                          type: string
+                        name:
+                          description: Name of the object being referenced.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                            the Authorizer should report an error.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    subjects:
+                      description: |-
+                        Subjects contains an array of references to objects or user identities a ClusterPermission binding applies to.
+                        Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                        If both subject and subjects exist then only subjects will be used.
+                      items:
+                        description: |-
+                          Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                          or a value for non-objects such as user and group names.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup holds the API group of the referenced subject.
+                              Defaults to "" for ServiceAccount subjects.
+                              Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                              If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                            type: string
+                          name:
+                            description: Name of the object being referenced.
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                              the Authorizer should report an error.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                  required:
+                  - roleRef
+                  type: object
+                type: array
+                x-kubernetes-validations:
+                - message: Either subject or subjects has to exist in every roleBinding
+                  rule: self.all(i, has(i.subject) || has(i.subjects))
+              roles:
+                description: Roles represents roles that are being created on the
+                  managed cluster
+                items:
+                  description: Role represents the Role that is being created on the
+                    managed cluster
+                  properties:
+                    namespace:
+                      description: Namespace of the Role for that is being created
+                        on the managed cluster
+                      type: string
+                    namespaceSelector:
+                      description: |-
+                        NamespaceSelector define the general labelSelector which namespace to apply the rules to
+                        Note: the namespace must exists on the hub cluster
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    rules:
+                      description: Rules holds all the PolicyRules for this Role
+                      items:
+                        description: |-
+                          PolicyRule holds information that describes a policy rule, but does not contain information
+                          about who the rule applies to or which namespace the rule applies to.
+                        properties:
+                          apiGroups:
+                            description: |-
+                              APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+                              the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          nonResourceURLs:
+                            description: |-
+                              NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+                              Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+                              Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          resourceNames:
+                            description: ResourceNames is an optional white list of
+                              names that the rule applies to.  An empty set means
+                              that everything is allowed.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          resources:
+                            description: Resources is a list of resources this rule
+                              applies to. '*' represents all resources.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          verbs:
+                            description: Verbs is a list of Verbs that apply to ALL
+                              the ResourceKinds contained in this rule. '*' represents
+                              all verbs.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - verbs
+                        type: object
+                      type: array
+                  required:
+                  - rules
+                  type: object
+                type: array
+              validate:
+                description: |-
+                  Validate enables validation of roles and clusterroles on the managed cluster using ManifestWork
+                  When enabled, the controller will create a validation ManifestWork to check if the referenced
+                  roles and clusterroles exist on the managed cluster
+                type: boolean
+            type: object
+          status:
+            description: ClusterPermissionStatus defines the observed state of ClusterPermission
+            properties:
+              conditions:
+                description: Conditions is the condition list.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
RBAC Role Assignment CR Implementation - creation mechanism

This PR implements a way to discover all managed clusters from managed cluster sets. It also refactors status logic/variables. Lastly, it implements a function to get ClusterPermission by a pre-set management label. The label will be added to ClusterPermissions during creation by the controller.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-23014

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [x] ✨ Feature  
- [x] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No test logs/printing output, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled

#### If Feature

- [ ] All acceptance criteria met
- [x] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->