### PR TITLE
ACM-24292 Fix ClusterPermission empty subject field

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -13,6 +13,6 @@ build-prow:
 
 # Runs test target from Makefile
 .PHONY: unit-tests
-unit-tests:
+unit-tests: setup-envtest
 	@echo "Run unit-tests"
-	go test $$(go list ./... | grep -v /e2e) -timeout 500s -v -short -coverprofile coverage.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -timeout 500s -v -short -coverprofile coverage.out

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
 	open-cluster-management.io/api v1.0.0
-	open-cluster-management.io/cluster-permission v0.16.0
+	open-cluster-management.io/cluster-permission v0.16.2
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6J
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 open-cluster-management.io/api v1.0.0 h1:54QllH9DTudCk6VrGt0q8CDsE3MghqJeTaTN4RHZpE0=
 open-cluster-management.io/api v1.0.0/go.mod h1:/OeqXycNBZQoe3WG6ghuWsMgsKGuMZrK8ZpsU6gWL0Y=
-open-cluster-management.io/cluster-permission v0.16.0 h1:3q9aaBN92LzbpQnYIOI9vBC+ejtqL0ftoh/JUiPa1gg=
-open-cluster-management.io/cluster-permission v0.16.0/go.mod h1:Ejytz7ZDoxDWqiGSDDYYIYKGZQHUgFZuCgFqvTnZSzE=
+open-cluster-management.io/cluster-permission v0.16.2 h1:oJCf3gAaDR3M2xJwdQZ4GPYsyAFLx8Wi+GpHCL5oSxg=
+open-cluster-management.io/cluster-permission v0.16.2/go.mod h1:Ejytz7ZDoxDWqiGSDDYYIYKGZQHUgFZuCgFqvTnZSzE=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Fix the empty `subject` field the gets created when we generate ClusterPermissions.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-24292

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No test logs/printing output, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled

#### If Feature

- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->