### PR TITLE
ACM-30617 and ACM-30511 - Update readme with subject api changes and minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This operator simplifies the management of RBAC policies in multicluster environ
 
 Creating `MulticlusterRoleAssignment` resources will create `ClusterPermission` resources which in turn creates the RBAC resources in the targeted managed clusters. The RBAC resources can be `ClusterRoleBinding` or `RoleBinding`. For more information on `ClusterPermission` resources, refer to the [ClusterPermission repo](https://github.com/stolostron/cluster-permission).
 
+The operator uses annotation-based ownership tracking to support multiple MulticlusterRoleAssignments managing the same ClusterPermission. Each binding in the ClusterPermission is annotated with its owning MulticlusterRoleAssignment, allowing safe concurrent management.
+
 ## Quick Start
 
 ### Prerequisites
@@ -71,7 +73,7 @@ The `MulticlusterRoleAssignment` custom resource defines role assignments across
 |-------|------|-------------|----------|
 | `name` | `string` | Name of the role assignment | Yes |
 | `clusterRole` | `string` | Name of the cluster role to assign | Yes |
-| `targetNamespaces` | `[]string` | Namespaces to apply the role (all if empty) | No |
+| `targetNamespaces` | `[]string` | Namespaces to apply the role (cluster-wide if empty) | No |
 | `clusterSelection` | `ClusterSelection` | Cluster selection criteria | Yes |
 
 #### ClusterSelection Fields

--- a/README.md
+++ b/README.md
@@ -85,8 +85,17 @@ The `MulticlusterRoleAssignment` custom resource defines role assignments across
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
-| `subject` | `rbacv1.Subject` | The user or group for the role assignment | Yes |
+| `subject` | `Subject` | The user, group, or service account for all role assignments | Yes |
 | `roleAssignments` | `[]RoleAssignment` | List of role assignments for different clusters | Yes |
+
+#### Subject Fields
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| `apiGroup` | `string` | API group of the subject. Must be empty or `rbac.authorization.k8s.io` for User/Group. Must be empty (or omitted) for ServiceAccount. | No |
+| `kind` | `string` | Kind of subject (User, Group, or ServiceAccount) | Yes |
+| `name` | `string` | Name of the subject | Yes |
+| `namespace` | `string` | Namespace of the subject. Must NOT be set for User/Group. Must be set for ServiceAccount. | No (except required for ServiceAccount) |
 
 #### RoleAssignment Fields
 

--- a/README.md
+++ b/README.md
@@ -43,38 +43,6 @@ Creating `MulticlusterRoleAssignment` resources will create `ClusterPermission` 
    kubectl get pods -n multicluster-role-assignment-system
    ```
 
-### Basic Usage
-
-Create a `MulticlusterRoleAssignment` to grant a user view access to specific clusters:
-
-```yaml
-apiVersion: rbac.open-cluster-management.io/v1beta1
-kind: MulticlusterRoleAssignment
-metadata:
-  name: developer-view-access
-  namespace: open-cluster-management-global-set
-spec:
-  subject:
-    kind: User
-    name: jane.developer
-  roleAssignments:
-  - name: view-access
-    clusterRole: view
-    targetNamespaces:
-    - development
-    - staging
-    clusterSelection:
-      type: placements
-      placements:
-      - name: dev-clusters
-        namespace: open-cluster-management-global-set
-```
-
-This example:
-- Grants the user `jane.developer` the `view` cluster role
-- Applies the role to the `development` and `staging` namespaces
-- Targets clusters selected by the `dev-clusters` Placement resource
-
 ## API Reference
 
 ### MulticlusterRoleAssignment
@@ -129,6 +97,37 @@ The operator reports the status of each role assignment, including:
 
 ## Examples
 
+### Basic Usage
+
+```yaml
+apiVersion: rbac.open-cluster-management.io/v1beta1
+kind: MulticlusterRoleAssignment
+metadata:
+  name: developer-view-access
+  namespace: open-cluster-management-global-set
+spec:
+  subject:
+    kind: User
+    name: jane.developer
+    apiGroup: rbac.authorization.k8s.io
+  roleAssignments:
+  - name: view-access
+    clusterRole: view
+    targetNamespaces:
+    - development
+    - staging
+    clusterSelection:
+      type: placements
+      placements:
+      - name: dev-clusters
+        namespace: open-cluster-management-global-set
+```
+
+This example:
+- Grants the user `jane.developer` the `view` cluster role
+- Applies the role to the `development` and `staging` namespaces
+- Targets clusters selected by the `dev-clusters` Placement resource
+
 ### Multiple Role Assignments
 
 ```yaml
@@ -161,6 +160,36 @@ spec:
       - name: dev-clusters
         namespace: open-cluster-management-global-set
 ```
+
+This example shows how a single MulticlusterRoleAssignment can have many roleAssignments.
+
+### ServiceAccount Assignment
+
+```yaml
+apiVersion: rbac.open-cluster-management.io/v1beta1
+kind: MulticlusterRoleAssignment
+metadata:
+  name: automation-serviceaccount
+  namespace: open-cluster-management-global-set
+spec:
+  subject:
+    kind: ServiceAccount
+    name: automation-account
+    namespace: automation
+  roleAssignments:
+  - name: pod-reader
+    clusterRole: view
+    targetNamespaces:
+    - production
+    - staging
+    clusterSelection:
+      type: placements
+      placements:
+      - name: prod-clusters
+        namespace: open-cluster-management-global-set
+```
+
+This example grants a ServiceAccount access to view resources in specific namespaces across selected clusters.
 
 ## Development
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -59,3 +59,13 @@ var _ = BeforeSuite(func() {
 	_, err = utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to install CRDs")
 })
+
+var _ = AfterSuite(func() {
+	By("undeploying the controller-manager")
+	cmd := exec.Command("make", "undeploy")
+	_, _ = utils.Run(cmd)
+
+	By("removing manager namespace")
+	cmd = exec.Command("kubectl", "delete", "ns", namespace)
+	_, _ = utils.Run(cmd)
+})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -199,14 +199,6 @@ var _ = Describe("Manager", Ordered, func() {
 		By(fmt.Sprintf("cleaning up %s namespace", openClusterManagementGlobalSetNamespace))
 		cmd = exec.Command("kubectl", "delete", "ns", openClusterManagementGlobalSetNamespace)
 		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("removing manager namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", namespace)
-		_, _ = utils.Run(cmd)
 	})
 
 	BeforeEach(func() {


### PR DESCRIPTION
# 📝 Summary
Updated readme to reflect changes from #279 + some other minor updates. Added example for service account subject usage. Also had to do a slight fix for e2e test cleanup because CRD was getting uninstalled sometimes before CRD tests ran.

Ticket Summary (Title):
MulticlusterRoleAssignment allows invalid spec field characters
SAR-01: MultiClusterRoleAssignment CRD lacks validation on subject.kind field

Ticket Link:
https://issues.redhat.com/browse/ACM-30617
https://issues.redhat.com/browse/ACM-30511

**Type of Change:**
<!-- Select one -->
- [ ] 🐞 Bug Fix
- [x] 🧹 Chore
- [ ] ✨ Feature
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No test logs/printing output, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled

#### If Feature

- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API reference with expanded field descriptions, ownership tracking explanation, and comprehensive usage examples including service accounts and multi-assignment scenarios.

* **Tests**
  * Reorganized end-to-end test cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->