### PR TITLE
Migrate Konflux configs for ACM 5.0

### DIFF
--- a/.tekton/multicluster-role-assignment-acm-50-pull-request.yaml
+++ b/.tekton/multicluster-role-assignment-acm-50-pull-request.yaml
@@ -3,18 +3,18 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-role-assignment?rev={{revision}}
-    build.appstudio.redhat.com/commit_sha: "{{revision}}"
-    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
-    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch in ["main", "release-2.17"]
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch in ["main", "release-5.0"]
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-acm-217
-    appstudio.openshift.io/component: multicluster-role-assignment-acm-217
+    appstudio.openshift.io/application: release-acm-50
+    appstudio.openshift.io/component: multicluster-role-assignment-acm-50
     pipelines.appstudio.openshift.io/type: build
-  name: multicluster-role-assignment-acm-217-on-pull-request
+  name: multicluster-role-assignment-acm-50-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -29,7 +29,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/multicluster-role-assignment-acm-217:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/multicluster-role-assignment-acm-50:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: build-platforms
@@ -49,9 +49,9 @@ spec:
       - name: pathInRepo
         value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-multicluster-role-assignment-acm-217
+    serviceAccountName: build-pipeline-multicluster-role-assignment-acm-50
   workspaces:
     - name: git-auth
       secret:
-        secretName: "{{ git_auth_secret }}"
+        secretName: '{{ git_auth_secret }}'
 status: {}

--- a/.tekton/multicluster-role-assignment-acm-50-push.yaml
+++ b/.tekton/multicluster-role-assignment-acm-50-push.yaml
@@ -3,17 +3,17 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-role-assignment?rev={{revision}}
-    build.appstudio.redhat.com/commit_sha: "{{revision}}"
-    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-2.17"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-5.0"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-acm-217
-    appstudio.openshift.io/component: multicluster-role-assignment-acm-217
+    appstudio.openshift.io/application: release-acm-50
+    appstudio.openshift.io/component: multicluster-role-assignment-acm-50
     pipelines.appstudio.openshift.io/type: build
-  name: multicluster-role-assignment-acm-217-on-push
+  name: multicluster-role-assignment-acm-50-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/multicluster-role-assignment-acm-217:{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/multicluster-role-assignment-acm-50:{{revision}}
     - name: build-platforms
       value:
         - linux/x86_64
@@ -55,9 +55,9 @@ spec:
       - name: pathInRepo
         value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-multicluster-role-assignment-acm-217
+    serviceAccountName: build-pipeline-multicluster-role-assignment-acm-50
   workspaces:
     - name: git-auth
       secret:
-        secretName: "{{ git_auth_secret }}"
+        secretName: '{{ git_auth_secret }}'
 status: {}


### PR DESCRIPTION
Automated migration via [`migrate-konflux.sh`](https://github.com/stolostron/governance-policy-framework/blob/main/build/branch-create/migrate-konflux.sh) script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated pipeline configurations to target ACM release 5.0 and the `release-5.0` branch instead of previous versions.
  * Updated build service accounts and container image repositories to align with the new release target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->