### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,49 @@
+ARG GO_VERSION=1.25
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+
+# Copy go manifests and source code
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY cmd/main.go cmd/main.go
+COPY api/ api/
+COPY internal/ internal/
+
+# Compile binary
+ENV GOEXPERIMENT=strictfipsruntime
+ENV BUILD_TAGS="strictfipsruntime"
+ENV CGO_ENABLED=1
+ENV GOFLAGS="-mod=readonly"
+RUN CGO_ENABLED=1 go build -tags ${BUILD_TAGS} -a -o manager cmd/main.go
+
+# Build actual image below
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+LABEL \
+    name="rhacm2/multicluster-role-assignment-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    com.redhat.component="multicluster-role-assignment" \
+    description="Kubernetes operator for multicluster role assignment management built for \
+Open Cluster Management (OCM) environments. Automates RBAC management across multiple clusters \
+by allowing users to define role assignments that get propagated to clusters within specified \
+ManagedClusterSets." \
+    io.k8s.description="Kubernetes operator for multicluster role assignment management built for \
+Open Cluster Management (OCM) environments. Automates RBAC management across multiple clusters \
+by allowing users to define role assignments that get propagated to clusters within specified \
+ManagedClusterSets." \
+    summary="Automates RBAC management across multiple clusters in Open Cluster Management environments." \
+    io.k8s.display-name="Red Hat Advanced Cluster Management Multicluster Role Assignment" \
+    io.openshift.tags="acm rbac multicluster ocm operator" \
+    url="https://github.com/stolostron/multicluster-role-assignment"
+
+WORKDIR /
+
+# Copy binary and license file
+COPY --from=builder /workspace/manager .
+RUN mkdir licenses/
+COPY LICENSE licenses/
+
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)