### PR TITLE
ACM-33762: build(go): bump minimum Go version to 1.25.9 for stdlib CVE remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ This example grants a ServiceAccount access to view resources in specific namesp
 
 ### Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - [yq](https://github.com/mikefarah/yq) v4+ - `go install github.com/mikefarah/yq/v4@latest`
 - Kubernetes cluster for testing
 - [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (for e2e tests)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-role-assignment
 
-go 1.25.0
+go 1.25.9
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.3


### PR DESCRIPTION
Our vulnerability scan reports multiple Go stdlib vulnerabilities while builds are using an older 1.25 patch level. Requiring Go 1.25.9 in go.mod ensures builds use a patched stdlib line without changing Docker image tags.
Fixes Go stdlib CVEs from the report, including:
- CRITICAL: CVE-2025-68121, CVE-2026-27143
- HIGH: CVE-2025-58187, CVE-2025-58188, CVE-2025-61723, CVE-2025-61725, CVE-2025-61726, CVE-2025-61729, CVE-2025-61731, CVE-2025-61732, CVE-2026-25679, CVE-2026-27140, CVE-2026-27144, CVE-2026-32280, CVE-2026-32281, CVE-2026-32283.

Ref: https://redhat.atlassian.net/browse/ACM-33762

**Type of Change:**
<!-- Select one -->
- [x] 🐞 Bug Fix
- [ ] 🧹 Chore
- [ ] ✨ Feature
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No test logs/printing output, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled

#### If Feature

- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go version requirement for development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->