### PR TITLE
Pin yq version in validate-rbac workflow

### DIFF
--- a/.github/workflows/validate-rbac.yml
+++ b/.github/workflows/validate-rbac.yml
@@ -20,7 +20,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install yq
-        run: go install github.com/mikefarah/yq/v4@latest
+        run: go install github.com/mikefarah/yq/v4@v4.53.2
 
       - name: Run make manifests
         run: make manifests


### PR DESCRIPTION
## Summary
- Pin `github.com/mikefarah/yq/v4` to `v4.53.2` instead of `@latest` in the validate-rbac workflow
- Resolves SonarCloud warning: "Dependency versions are not predictable. Use a lock-file enforcing command instead."

## Test plan
- [ ] Verify `Validate RBAC Sync` workflow passes with pinned version
- [ ] Confirm SonarCloud no longer flags this file

Made with [Cursor](https://cursor.com)