### PR TITLE
ACM-34424 - Unauthorized errors in VirtualMachine Overview and Migration Storage Plans for non-kubeadmin users fix

### DIFF
--- a/charts/fine-grained-rbac/templates/acm-roles-addontemplate.yaml
+++ b/charts/fine-grained-rbac/templates/acm-roles-addontemplate.yaml
@@ -128,6 +128,22 @@ spec:
               - get
               - list
               - watch
+            - apiGroups:
+              - migrations.kubevirt.io
+              resources:
+              - multinamespacevirtualmachinestoragemigrationplans
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - observability.open-cluster-management.io
+              resources:
+              - multiclusterobservabilities
+              verbs:
+              - get
+              - list
+              - watch
         - apiVersion: rbac.authorization.k8s.io/v1
           kind: ClusterRole
           metadata:
@@ -270,6 +286,22 @@ spec:
               - update
               - patch
               - delete
+            - apiGroups:
+              - migrations.kubevirt.io
+              resources:
+              - multinamespacevirtualmachinestoragemigrationplans
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - observability.open-cluster-management.io
+              resources:
+              - multiclusterobservabilities
+              verbs:
+              - get
+              - list
+              - watch
         - apiVersion: rbac.authorization.k8s.io/v1
           kind: ClusterRole
           metadata:


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
fixing unauthorized error for virtualmachine page for 4.22

**Ticket Link:**  
[ACM-34424](https://redhat.atlassian.net/browse/ACM-34424)

**Type of Change:**
<!-- Select one -->
- [X] 🐞 Bug Fix
- [ ] 🧹 Chore
- [ ] ✨ Feature
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No test logs/printing output, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled

#### If Feature

- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

[ACM-34424]: https://redhat.atlassian.net/browse/ACM-34424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RBAC permissions to enable read-only access to additional resources for observability and virtual machine storage migrations. Both view and admin roles now include permissions to get, list, and watch these resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->