### PR TITLE
chore: ignore cluster-permission dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,4 @@ updates:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+      - dependency-name: "open-cluster-management.io/cluster-permission"


### PR DESCRIPTION
The cluster-permission v0.16.2 release has breaking API changes (removed ClusterRoleBindingStatus, RoleBindingStatus, ResourceStatus) that are incompatible with the current controller. Ignore all updates to this dependency until the controller is updated to handle the new API.

# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

**Type of Change:**
<!-- Select one -->
- [ ] 🐞 Bug Fix
- [X] 🧹 Chore
- [ ] ✨ Feature
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No test logs/printing output, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled

#### If Feature

- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->