### PR TITLE
ACM-34985 - update clusterpermission to v0.17.0 and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,4 +27,3 @@ updates:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
-      - dependency-name: "open-cluster-management.io/cluster-permission"

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	k8s.io/apimachinery v0.35.5
 	k8s.io/client-go v0.35.5
 	open-cluster-management.io/api v1.3.0
-	open-cluster-management.io/cluster-permission v0.16.1-0.20251223064118-28a3fb8c91bd
+	open-cluster-management.io/cluster-permission v0.17.0
 	sigs.k8s.io/controller-runtime v0.23.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzk
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 open-cluster-management.io/api v1.3.0 h1:Q3miH38BE3N5+PesHQ0kcFi5nhX5350m7OJWapZcVqY=
 open-cluster-management.io/api v1.3.0/go.mod h1:t0DsBv4gjIo9ojd7GYfA2tcEMpNf0h5Ix68pFDXwNSk=
-open-cluster-management.io/cluster-permission v0.16.1-0.20251223064118-28a3fb8c91bd h1:rqR+gq//5cAg97uHCsIwEoBVJHwwkQcH/UcZlBf3XLU=
-open-cluster-management.io/cluster-permission v0.16.1-0.20251223064118-28a3fb8c91bd/go.mod h1:bhOvZVbGw/kLOkEjdNSZlFS0Rur3mV2MBvdIdiueneA=
+open-cluster-management.io/cluster-permission v0.17.0 h1:SGgzjxmbCNfBbB4o9PavtbSypGwYJ2MDPouZW8Kh20M=
+open-cluster-management.io/cluster-permission v0.17.0/go.mod h1:NlRs8bgXL+09hOP6bN3P+JT5zXKuVwnCSb95ovar47U=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.1 h1:Ac6yUpjm3TIUHrG6+aaacSJ/UzsCGFIj6C9VYNfCOMk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.1/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
ACM-34985 Update multicluster-role-assignment to import cluster-permission v0.17.0

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-34985

**Type of Change:**
- [ ] 🐞 Bug Fix
- [x] 🧹 Chore
- [ ] ✨ Feature
- [ ] 🔧 Refactor
- [x] 💸 Tech Debt
- [ ] 🧪 Test-related
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-34985 Update cluster-permission to v0.17.0`)
- [x] Code builds and runs locally without errors
- [x] No test logs/printing output, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled

#### If Feature

- N/A

#### If Bugfix

- N/A

---

### 🗒️ Notes for Reviewers

Replaces the `cluster-permission` pseudo-version pin with a clean tagged release:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies to newer versions for improved system compatibility
  * Refined dependency update configuration to better manage minor and major version releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->