### PR TITLE
ACM-30253 Label storagemigrate ClusterRoles for ACM console discovery

### DIFF
--- a/charts/fine-grained-rbac/templates/policy-virt-clusterroles-policy.yaml
+++ b/charts/fine-grained-rbac/templates/policy-virt-clusterroles-policy.yaml
@@ -57,6 +57,30 @@ spec:
                   rbac.open-cluster-management.io/filter: vm-clusterroles
                   clusterview.open-cluster-management.io/discoverable: "true"
           {{ `{{- end }}` }}
+          {{ `{{- $storagemigrate := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "migrations.kubevirt.io:storagemigrate" -}}` }}
+          {{ `{{- if $storagemigrate }}` }}
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: migrations.kubevirt.io:storagemigrate
+                labels:
+                  rbac.open-cluster-management.io/filter: vm-clusterroles
+                  clusterview.open-cluster-management.io/discoverable: "true"
+          {{ `{{- end }}` }}
+          {{ `{{- $storagemigrateMultins := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "migrations.kubevirt.io:storagemigrate-multins" -}}` }}
+          {{ `{{- if $storagemigrateMultins }}` }}
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: migrations.kubevirt.io:storagemigrate-multins
+                labels:
+                  rbac.open-cluster-management.io/filter: vm-clusterroles
+                  clusterview.open-cluster-management.io/discoverable: "true"
+          {{ `{{- end }}` }}
         remediationAction: enforce
         severity: medium
   remediationAction: enforce

--- a/charts/fine-grained-rbac/templates/policy-virt-clusterroles-policy.yaml
+++ b/charts/fine-grained-rbac/templates/policy-virt-clusterroles-policy.yaml
@@ -57,6 +57,18 @@ spec:
                   rbac.open-cluster-management.io/filter: vm-clusterroles
                   clusterview.open-cluster-management.io/discoverable: "true"
           {{ `{{- end }}` }}
+          {{ `{{- $migrationsView := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "migrations.kubevirt.io:view" -}}` }}
+          {{ `{{- if $migrationsView }}` }}
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: migrations.kubevirt.io:view
+                labels:
+                  rbac.open-cluster-management.io/filter: vm-clusterroles
+                  clusterview.open-cluster-management.io/discoverable: "true"
+          {{ `{{- end }}` }}
           {{ `{{- $storagemigrate := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "migrations.kubevirt.io:storagemigrate" -}}` }}
           {{ `{{- if $storagemigrate }}` }}
           - complianceType: musthave


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Storage migration greyed out for RBAC users -- missing permission in ClusterRoles

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-30253

**Type of Change:**
- [x] ✨ Feature

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No test logs/printing output, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled

#### If Feature

- [x] All acceptance criteria met
- [x] Unit test coverage added or updated (N/A -- declarative policy, no code logic)
- [x] Relevant documentation or comments included

---

### 🗒️ Notes for Reviewers

**What this PR does:**

Adds two new ClusterRole entries to the `policy-virt-clusterroles` governance policy, labeling the kubevirt-migration-operator's storage migration roles with ACM discoverable labels:

- `migrations.kubevirt.io:storagemigrate` -- single-namespace VM storage migration
- `migrations.kubevirt.io:storagemigrate-multins` -- multi-namespace VM storage migration

Labels added:
- `clusterview.open-cluster-management.io/discoverable: "true"` -- makes roles visible to the UserPermission API
- `rbac.open-cluster-management.io/filter: vm-clusterroles` -- enables the ACM console to show these roles in the VM role assignment UI

**Why:**

The upstream kubevirt-migration-operator ships these ClusterRoles (via [kubevirt/kubevirt-migration-operator#79](https://github.com/kubevirt/kubevirt-migration-operator/pull/79)) starting in OCP 4.20, but without ACM labels they are invisible to the console. Admins cannot assign storage migration permissions to RBAC users through the UI, causing the "Storage" option under Migration to remain greyed out for non-cluster-admin users.

**How it works:**

The policy uses `lookup` to check if each ClusterRole exists on the target cluster before patching labels. This is a no-op on clusters without the kubevirt-migration-operator (or older versions without these roles).

**Testing:**

Manually verified on a live ACM environment:
1. Created test ClusterRoles without labels
2. Applied the updated policy
3. Confirmed the governance framework labeled both roles within ~30 seconds
4. Policy returned to `Compliant` with all 5 entries passing

**Backport consideration:**

The policy file exists in `release-2.16` and later. Since the `lookup` makes this safe on clusters without the roles, backporting to all branches with the policy is recommended.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conditional compliance checks for storage migration-related cluster roles.
  * When the relevant roles are present, the system now validates their required compliance settings automatically, including discoverability labeling for smoother detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->