### PR TITLE
feat: add acm-vm-fleet ClusterRoles with processedtemplates permission for VM creation

### DIFF
--- a/charts/fine-grained-rbac/templates/acm-roles-addontemplate.yaml
+++ b/charts/fine-grained-rbac/templates/acm-roles-addontemplate.yaml
@@ -473,10 +473,6 @@ spec:
               - get
               - list
               - watch
-              - create
-              - update
-              - patch
-              - delete
             - apiGroups:
               - kubevirt.io
               resources:

--- a/charts/fine-grained-rbac/templates/acm-roles-addontemplate.yaml
+++ b/charts/fine-grained-rbac/templates/acm-roles-addontemplate.yaml
@@ -333,6 +333,73 @@ spec:
               - userpermissions
               verbs:
               - list
+            - apiGroups:
+              - ""
+              resources:
+              - namespaces
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - project.openshift.io
+              resources:
+              - projects
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - kubevirts
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - user.openshift.io
+              resources:
+              - users
+              - groups
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - instancetype.kubevirt.io
+              resources:
+              - virtualmachineclusterinstancetypes
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - template.openshift.io
+              resources:
+              - templates
+              - processedtemplates
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - cdi.kubevirt.io
+              resources:
+              - datasources
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - hco.kubevirt.io
+              resources:
+              - hyperconvergeds
+              verbs:
+              - get
+              - list
+              - watch
         - apiVersion: rbac.authorization.k8s.io/v1
           kind: ClusterRole
           metadata:
@@ -382,6 +449,100 @@ spec:
               - userpermissions
               verbs:
               - list
+            - apiGroups:
+              - ""
+              resources:
+              - namespaces
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              verbs:
+              - get
+              - list
+              - watch
+              - patch
+            - apiGroups:
+              - project.openshift.io
+              resources:
+              - projects
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - kubevirt.io
+              resources:
+              - kubevirts
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - user.openshift.io
+              resources:
+              - users
+              - groups
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - instancetype.kubevirt.io
+              resources:
+              - virtualmachineclusterinstancetypes
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - template.openshift.io
+              resources:
+              - templates
+              - processedtemplates
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - cdi.kubevirt.io
+              resources:
+              - datasources
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - hco.kubevirt.io
+              resources:
+              - hyperconvergeds
+              verbs:
+              - get
+              - list
+              - watch
         - apiVersion: rbac.authorization.k8s.io/v1
           kind: ClusterRole
           metadata:


### PR DESCRIPTION
## Summary

Fixes Problem 4: VM creation from templates on hosted clusters fails because `kubevirt.io:edit` alone is not sufficient. The UI requires the `create` verb on `processedtemplates.template.openshift.io` to convert a template into a VM manifest.

**Customer report:** User needs `kubevirt.io:edit` on the hub cluster and a matching namespace on the hub.

**Engineering finding:** The issue is that `kubevirt.io:edit` alone is not sufficient for VM creation from templates. The UI also requires `create` verb on `processedtemplates.template.openshift.io` to convert a template into a VM manifest.

These ClusterRoles are required to:
- View the fleet virtualization template list on the template page
- Create a VM from the template list page

Jira: https://redhat.atlassian.net/browse/ACM-37255

## Changes

Add the following permissions to `acm-vm-fleet:view` (`get/list/watch`) and `acm-vm-fleet:admin` in `acm-roles-addontemplate.yaml`:

| Resource | API Group | view | admin |
|----------|-----------|------|-------|
| namespaces, configmaps | core | get/list/watch | get/list(/watch/patch) |
| projects | project.openshift.io | get/list/watch | get/list/watch |
| kubevirts | kubevirt.io | get/list/watch | full CRUD |
| users, groups | user.openshift.io | get/list/watch | get/list/watch |
| virtualmachineclusterinstancetypes | instancetype.kubevirt.io | get/list/watch | full CRUD |
| **templates, processedtemplates** | template.openshift.io | get/list/watch | **full CRUD** |
| datasources | cdi.kubevirt.io | get/list/watch | full CRUD |
| hyperconvergeds | hco.kubevirt.io | get/list/watch | get/list/watch |

## Test plan

- [ ] Assign `acm-vm-fleet:view` to a test user and verify the fleet virtualization template list is visible on the template page
- [ ] Assign `acm-vm-fleet:admin` to a test user and verify VM creation from the template list page succeeds (processedtemplates create verb)