### PR TITLE
ACM-38913 Add olmVersion and networkPolicies to Helm chart values

### DIFF
--- a/charts/fine-grained-rbac/templates/multicluster-role-assignment-networkpolicy.yaml
+++ b/charts/fine-grained-rbac/templates/multicluster-role-assignment-networkpolicy.yaml
@@ -1,0 +1,37 @@
+# NetworkPolicy for multicluster-role-assignment-controller pods.
+#
+# Ingress:
+#   - Metrics endpoint (port 8443) from Prometheus/monitoring
+#   - Health probes (port 8081) for liveness/readiness checks
+#
+# Egress (allow-all):
+#   The controller talks to the Kubernetes API server to manage
+#   ClusterPermissions, MultiClusterRoleAssignments, and PlacementDecisions.
+#   Because the API server endpoint IP and port are not statically known,
+#   egress is left unrestricted.
+{{- if .Values.global.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-role-assignment-controller
+  namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'
+  labels:
+    app.kubernetes.io/name: multicluster-role-assignment
+    app.kubernetes.io/managed-by: multiclusterhub-operator
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: multicluster-role-assignment-controller
+      app.kubernetes.io/name: multicluster-role-assignment
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - ports:
+    - port: 8443
+      protocol: TCP
+    - port: 8081
+      protocol: TCP
+  egress:
+  - {}
+{{- end }}

--- a/charts/fine-grained-rbac/values.yaml
+++ b/charts/fine-grained-rbac/values.yaml
@@ -5,8 +5,11 @@ global:
     multicluster_role_assignment: quay.io/stolostron/multicluster-role-assignment:latest
   templateOverrides: {}
   namespace: default
+  olmVersion: v0
   pullSecret: null
   pullPolicy: Always
+  networkPolicies:
+    enabled: true
 hubconfig:
   nodeSelector: null
   proxyConfigs: {}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,7 +69,7 @@ func main() {
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
-		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
+		"Use :8443 for HTTPS or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+


### PR DESCRIPTION
## Summary
- Adds `olmVersion: v0` and `networkPolicies.enabled: true` to the fine-grained-rbac Helm chart `values.yaml`
- Prevents the MCH operator chart copy automation from stripping these fields during syncs

## Context
The MCH operator has an automated chart copy process that syncs `charts/fine-grained-rbac/` from this repo into `pkg/templates/charts/toggle/fine-grained-rbac/` in the [multiclusterhub-operator](https://github.com/stolostron/multiclusterhub-operator) repo. Because these fields were missing from the source, the automation was removing them (see [stolostron/multiclusterhub-operator#4493](https://github.com/stolostron/multiclusterhub-operator/pull/4493)).

All other ACM component charts include these fields in their `values.yaml`.

Jira: [ACM-38913](https://redhat.atlassian.net/browse/ACM-38913)

## Test plan
- [ ] Verify the MCH chart copy automation no longer strips `olmVersion` and `networkPolicies` from the fine-grained-rbac values

[ACM-38913]: https://redhat.atlassian.net/browse/ACM-38913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional network policies to secure controller traffic.
  * Restricted ingress to health probe and metrics ports while allowing controller egress.
  * Enabled network policies by default in the deployment configuration.
  * Added support for the OLM v0 configuration.

* **Documentation**
  * Clarified metrics configuration guidance: HTTPS uses port 8443, while 0 disables metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->