### PR TITLE
ACM-37273 - adding clusterrole for hcp proxy

### DIFF
--- a/charts/fine-grained-rbac/templates/acm-roles-addontemplate.yaml
+++ b/charts/fine-grained-rbac/templates/acm-roles-addontemplate.yaml
@@ -572,3 +572,114 @@ spec:
               - get
               - list
               - watch
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            labels:
+              rbac.open-cluster-management.io/filter: hcp-clusterroles
+              clusterview.open-cluster-management.io/discoverable: "true"
+            name: acm-hcp-hosting:view
+          rules:
+            - apiGroups:
+              - hypershift.openshift.io
+              resources:
+              - hostedclusters
+              - hostedclusters/status
+              - nodepools
+              - nodepools/status
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - namespaces
+              - configmaps
+              - events
+              - pods
+              - services
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - events.k8s.io
+              resources:
+              - events
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - cluster.open-cluster-management.io
+              resources:
+              - managedclusters
+              verbs:
+              - get
+              - list
+              - watch
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            labels:
+              rbac.open-cluster-management.io/filter: hcp-clusterroles
+              clusterview.open-cluster-management.io/discoverable: "true"
+            name: acm-hcp-hosting:admin
+          rules:
+            - apiGroups:
+              - hypershift.openshift.io
+              resources:
+              - hostedclusters
+              - hostedclusters/status
+              - hostedclusters/finalizers
+              - nodepools
+              - nodepools/status
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              - configmaps
+              - services
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - ""
+              resources:
+              - namespaces
+              - events
+              - pods
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - events.k8s.io
+              resources:
+              - events
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - cluster.open-cluster-management.io
+              resources:
+              - managedclusters
+              verbs:
+              - get
+              - list
+              - watch

--- a/charts/fine-grained-rbac/templates/binding-policy-virt-rbac-placementbinding.yaml
+++ b/charts/fine-grained-rbac/templates/binding-policy-virt-rbac-placementbinding.yaml
@@ -17,3 +17,6 @@ subjects:
 - apiGroup: policy.open-cluster-management.io
   kind: Policy
   name: policy-virt-oauth
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: policy-hcp-clusterroles

--- a/charts/fine-grained-rbac/templates/policy-hcp-clusterroles-policy.yaml
+++ b/charts/fine-grained-rbac/templates/policy-hcp-clusterroles-policy.yaml
@@ -1,0 +1,50 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/description: ""
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  labels:
+    open-cluster-management.io/policy-hcp: hcp-rbac
+    velero.io/exclude-from-backup: 'true'
+  name: policy-hcp-clusterroles
+  namespace: open-cluster-management-global-set
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: policy-hcp-clusterroles
+      spec:
+        object-templates-raw: |
+          {{ `{{- $hcpAdmin := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "hypershift-admin" -}}` }}
+          {{ `{{- if $hcpAdmin }}` }}
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: hypershift-admin
+                labels:
+                  rbac.open-cluster-management.io/filter: hcp-clusterroles
+                  clusterview.open-cluster-management.io/discoverable: "true"
+          {{ `{{- end }}` }}
+          {{ `{{- $hcpReader := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "hypershift-reader" -}}` }}
+          {{ `{{- if $hcpReader }}` }}
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: hypershift-reader
+                labels:
+                  rbac.open-cluster-management.io/filter: hcp-clusterroles
+                  clusterview.open-cluster-management.io/discoverable: "true"
+          {{ `{{- end }}` }}
+        remediationAction: enforce
+        severity: medium
+  remediationAction: enforce


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
As a hub admin, I can grant a user access to specific hosting clusters for hcp from-hub using MulticlusterRoleAssignment

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-37273

**Type of Change:**
- [ ] 🐞 Bug Fix
- [ ] 🧹 Chore
- [x] ✨ Feature
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No test logs/printing output, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled

#### If Feature

- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [x] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

Adds HCP hosting cluster RBAC support to the Helm chart:

- **AddOnTemplate**: Two new ClusterRoles deployed to managed clusters via the addon framework:
  - `acm-hcp-hosting:view` — read-only access to HyperShift resources (`hostedclusters`, `nodepools`, status subresources)
  - `acm-hcp-hosting:admin` — full CRUD on HyperShift resources including secrets/configmaps for `hcp from-hub create`
- **Policy**: `policy-hcp-clusterroles` ensures pre-existing HyperShift ClusterRoles (`hypershift-admin`, `hypershift-reader`) get discovery labels, following the same pattern as `policy-virt-clusterroles`
- **PlacementBinding**: Updated to include the new HCP policy

Once these ClusterRoles are deployed to hosting clusters, hub admins can create a `MulticlusterRoleAssignment` referencing `acm-hcp-hosting:admin` to grant users access to specific hosting clusters for `hcp from-hub` operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only and administrative access roles for managing hosted control planes, clusters, node pools, and related resources.
  * Added policy-based enforcement for HyperShift administrative and reader permissions.
  * Enabled automatic application of the new access policy through placement bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->